### PR TITLE
add basic gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+#snapcraft specifics
+parts
+stage
+prime


### PR DESCRIPTION
excludes parts/ stage/ and prime/ directories which are created by
snapcraft when not using cleanbuild.