### PR TITLE
add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[*.yaml]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Add .editorconfig to enforce using spaces for indentation in `snapcraft.yaml` when the editor supports it. This prevents vscode with the relevant plugin from reverting to tabs all the bloomin time and thereby killing snapcraft builds until I convert tabs to spaces again..(!)