### PR TITLE
Improve Git tracking ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 #snapcraft specifics
-parts
-stage
-prime
+/parts/
+/stage/
+/prime/
+
 *.snap
+
 .snapcraft
 __pycache__
 *.pyc
+*_source.tar.bz2


### PR DESCRIPTION
This patch brings several improvements to the Git ignore rules:

* Be more strict ignoring the special folders so that it won't match other things.
* Adds rules specific to `snapcraft cleanbuild`
* Cosmetic fixes

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>