### PR TITLE
github: build pull requests and pushes to master and release branches

### DIFF
--- a/.github/workflows/snap-build.yaml
+++ b/.github/workflows/snap-build.yaml
@@ -1,0 +1,31 @@
+name: snap-build
+on:
+  push:
+    branches:
+      - master
+      - release/**
+  pull_request:
+
+jobs:
+  snap-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+
+      - name: Build snap
+        id: build
+        uses: snapcore/action-build@v1
+
+      ### Enable this step if you want to publish builds of master to
+      ### the edge channel of your project.  You will neeed to add a
+      ### secret holding store credentials as described here:
+      ###     https://github.com/snapcore/action-publish
+      #
+      #- name: Publish to edge channel
+      #  if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      #  uses: snapcore/action-publish@v1
+      #  with:
+      #    store_login: ${{ secrets.STORE_LOGIN }}
+      #    snap: ${{ steps.build.outputs.snap }}
+      #    release: edge

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   we live in tweetspace and your description wants to look good in the snap
   store.
 
+base: core18
 confinement: devmode # use 'strict' once you have the right plugs and slots
 
 parts:


### PR DESCRIPTION
Now that Github Actions is generally available and we have an action that can build Snapcraft projects, it seems worth while to include a basic CI configuration in the template project.

This will build pull requests and pushes to master/release branches.  The workflow also includes a commented out step to publish builds.  It requires store credentials, so can't just work automatically when someone clones this template repo.  Users might also prefer to use the build.snapcraft.io service to publish builds.

I also updated the `snapcraft.yaml` file to specify a base, to avoid using legacy Snapcraft to build the project.

Note that the workflow added by this pull request will not run until it has actually been merged: this is because the target repo currently has no workflows.