### PR TITLE
Update Status Badge to the new build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ distributions.</p>
 
 <!-- Uncomment and modify this when you are provided a build status badge
 <p align="center">
-<a href="https://build.snapcraft.io/user/snapcrafters/fork-and-rename-me"><img src="https://build.snapcraft.io/badge/snapcrafters/fork-and-rename-me.svg" alt="Snap Status"></a>
+<a href="https://snapcraft.io/my-snap-name">
+  <img alt="enpass" src="https://snapcraft.io/my-snap-name/badge.svg" />
+</a>
+<a href="https://snapcraft.io/my-snap-name">
+  <img alt="enpass" src="https://snapcraft.io/my-snap-name/trending.svg?name=0" />
+</a>
 </p>
 -->
 


### PR DESCRIPTION
I noticed that the Build Status Badge mentioned in the README of the template was outdated. This is the code provided from the "Publicise" tab in the My Snaps section for GitHub Badges.