### PR TITLE
snapcraft.yaml: add core22 base

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   we live in tweetspace and your description wants to look good in the snap
   store.
 
+base: core22
 confinement: devmode # use 'strict' once you have the right plugs and slots
 
 parts:


### PR DESCRIPTION
Add a base to the template `snapcraft.yaml`. 

The missing base was preventing the template from working, which isn't a good user experience.  It was also failing the CI pipeline.